### PR TITLE
Improve streaming reliability and retry handling

### DIFF
--- a/ao3-transum (1).user.js
+++ b/ao3-transum (1).user.js
@@ -1490,34 +1490,109 @@
     }
   }
 
+  class RequestError extends Error {
+    constructor(message, options = {}) {
+      super(message || '请求失败');
+      this.name = 'RequestError';
+      if (options.cause) this.cause = options.cause;
+      if (typeof options.status === 'number') this.status = options.status;
+      if (typeof options.retryAfterMs === 'number') this.retryAfterMs = options.retryAfterMs;
+      if (options.isNetworkError) this.isNetworkError = true;
+      if (options.isTimeout) this.isTimeout = true;
+      if (typeof options.code === 'string') this.code = options.code;
+      if (typeof options.shouldRetry === 'boolean') this.shouldRetry = options.shouldRetry;
+    }
+  }
+
+  function parseRetryAfter(headerValue) {
+    if (!headerValue) return null;
+    const seconds = Number(headerValue);
+    if (!Number.isNaN(seconds)) return Math.max(0, seconds * 1000);
+    const date = Date.parse(headerValue);
+    if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+    return null;
+  }
+
+  const RETRIABLE_STATUS = new Set([403, 408, 409, 425, 429, 500, 502, 503, 504, 522, 524]);
+
+  function shouldRetryError(err) {
+    if (!err) return false;
+    if (typeof err.shouldRetry === 'boolean') return err.shouldRetry;
+    if (err.noRetry) return false;
+    if (typeof err.status === 'number' && RETRIABLE_STATUS.has(err.status)) return true;
+    if (err.isTimeout) return true;
+    if (err.isNetworkError) return true;
+    const msg = (err.message || '').toLowerCase();
+    if (!msg) return false;
+    return msg.includes('timeout') || msg.includes('network') || msg.includes('fetch failed') || msg.includes('connection');
+  }
+
+  function computeRetryDelay(err, attempt) {
+    if (err && typeof err.retryAfterMs === 'number' && err.retryAfterMs >= 0) {
+      return Math.min(10000, Math.max(0, err.retryAfterMs));
+    }
+    if (err && err.isTimeout) {
+      return Math.min(2000, 300 + (attempt - 1) * 200);
+    }
+    return Math.min(5000, 500 + (attempt - 1) * 400 + Math.random() * 600);
+  }
+
   /* ================= OpenAI-compatible + SSE ================= */
   function resolveEndpoint(baseUrl, apiPath){ if(!baseUrl) throw new Error('请在设置中填写 Base URL'); const hasV1=/\/v1\//.test(baseUrl); return hasV1? baseUrl : `${trimSlash(baseUrl)}/${trimSlash(apiPath||'v1/chat/completions')}`; }
   function resolveModelsEndpoint(baseUrl){ if(!baseUrl) throw new Error('请填写 Base URL'); const m=baseUrl.match(/^(.*?)(\/v1\/.*)$/); return m? `${m[1]}/v1/models` : `${trimSlash(baseUrl)}/v1/models`; }
   async function fetchJSON(url, key, body){
-    const res = await fetch(url, { method:'POST', headers:{'content-type':'application/json', ...(key?{'authorization':`Bearer ${key}`}:{})}, body: JSON.stringify(body) });
-    if(!res.ok){ const t=await res.text(); throw new Error(`HTTP ${res.status}: ${t.slice(0,500)}`); }
-    return await res.json();
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(key ? { 'authorization': `Bearer ${key}` } : {})
+        },
+        body: JSON.stringify(body)
+      }).catch(err => {
+        throw new RequestError(err?.message || '网络请求失败', { cause: err, isNetworkError: true });
+      });
+      const retryAfterMs = parseRetryAfter(res.headers.get('retry-after'));
+      if (!res.ok) {
+        const t = await res.text();
+        throw new RequestError(`HTTP ${res.status}: ${t.slice(0, 500)}`, {
+          status: res.status,
+          retryAfterMs
+        });
+      }
+      return await res.json();
+    } catch (err) {
+      if (err instanceof RequestError) throw err;
+      throw new RequestError(err?.message || '请求失败', { cause: err, isNetworkError: true });
+    }
   }
   function supportsStreamingFetch(){ try{ return !!(window.ReadableStream && window.TextDecoder && window.AbortController); } catch{ return false; } }
 
-  async function postChatWithRetry({ endpoint, key, payload, stream, onDelta, onDone, onError, onFinishReason, label }){
-    const cfg = settings.get().watchdog; let attempt = 0;
+  async function postChatWithRetry({ endpoint, key, payload, stream, onDelta, onDone, onError, onFinishReason, label, onAttempt }){
+    const cfg = settings.get().watchdog || {};
+    const maxRetry = Math.max(0, cfg.maxRetry || 0);
+    let attempt = 0;
     while (true) {
       attempt++;
       try {
+        if (typeof onAttempt === 'function') {
+          try { onAttempt(attempt); } catch (hookErr) { d('chat:onAttempt-error', { label, attempt, error: hookErr?.message }); }
+        }
         d('chat:start', {label, attempt, stream});
         await postChatOnce({ endpoint, key, payload, stream, onDelta, onDone, onFinishReason, label, idleMs: cfg.idleMs, hardMs: cfg.hardMs });
         d('chat:done', {label, attempt});
         return;
       } catch (e) {
-        d('chat:error', {label, attempt, error: e.message});
-        // 检查是否是超时错误，如果是则显示toast提示
-        if (e.message && (e.message.includes('idle-timeout') || e.message.includes('hard-timeout'))) {
+        d('chat:error', {label, attempt, error: e.message, status: e.status});
+        const msg = e?.message || '';
+        if (msg && (msg.includes('idle-timeout') || msg.includes('hard-timeout'))) {
           UI.toast(`块 ${label} 因超时失败`);
         }
-        if (attempt > (cfg.maxRetry||0)) { onError && onError(e); return; }
-        d('chat:retrying', {label, attemptNext: attempt+1});
-        await sleep(500 + Math.random()*700);
+        const canRetry = attempt <= maxRetry && shouldRetryError(e);
+        if (!canRetry) { if (onError) onError(e); return; }
+        const delay = computeRetryDelay(e, attempt + 1);
+        d('chat:retrying', {label, attemptNext: attempt+1, delay});
+        await sleep(delay);
       }
     }
   }
@@ -1542,61 +1617,153 @@
     }
   }
   async function fetchSSEWithAbort(url, key, body, onDelta, onFinishReason, {label='chunk', idleMs=10000, hardMs=90000} = {}){
-    const ac = new AbortController(); const startedAt = performance.now(); let lastTick = startedAt;
-    let bytes = 0, events = 0; let finishReason = null;
+    const ac = new AbortController();
+    const startedAt = performance.now();
+    let lastTick = startedAt;
+    let bytes = 0, events = 0;
+    let finishReason = null;
+    let retryAfterMs = null;
+    let reader = null;
+    let res;
 
     const useIdle = !(idleMs != null && idleMs < 0);
     const useHard = !(hardMs != null && hardMs < 0);
-    const idleTimer = useIdle ? setInterval(()=>{
+    const idleTimer = useIdle ? setInterval(() => {
       const now = performance.now();
-      if (now - lastTick > idleMs) { if (useIdle) clearInterval(idleTimer); if (useHard) clearTimeout(hardTimer); d('sse:idle-timeout', {label, ms: now - lastTick}); ac.abort(new Error('idle-timeout')); }
-    }, Math.max(2000, Math.floor((idleMs || 0)/4) || 2000)) : null;
-    const hardTimer = useHard ? setTimeout(()=>{ if (useIdle && idleTimer) clearInterval(idleTimer); d('sse:hard-timeout', {label, ms: hardMs}); ac.abort(new Error('hard-timeout')); }, hardMs) : null;
+      if (now - lastTick > idleMs) {
+        if (useIdle) clearInterval(idleTimer);
+        if (useHard) clearTimeout(hardTimer);
+        d('sse:idle-timeout', { label, ms: now - lastTick });
+        ac.abort(new Error('idle-timeout'));
+      }
+    }, Math.max(2000, Math.floor((idleMs || 0) / 4) || 2000)) : null;
+    const hardTimer = useHard ? setTimeout(() => {
+      if (useIdle && idleTimer) clearInterval(idleTimer);
+      d('sse:hard-timeout', { label, ms: hardMs });
+      ac.abort(new Error('hard-timeout'));
+    }, hardMs) : null;
 
-    try{
-      const res = await fetch(url, { method:'POST', headers:{ 'content-type':'application/json', ...(key?{'authorization':`Bearer ${key}`}:{}) }, body: JSON.stringify(body), signal: ac.signal });
-      if(!res.ok){ const t=await res.text(); throw new Error(`HTTP ${res.status}: ${t}`); }
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(key ? { 'authorization': `Bearer ${key}` } : {})
+        },
+        body: JSON.stringify(body),
+        signal: ac.signal
+      }).catch(err => {
+        throw new RequestError(err?.message || '网络请求失败', { cause: err, isNetworkError: true });
+      });
 
-      const reader = res.body.getReader(); const td=new TextDecoder('utf-8');
-      let buf=''; let eventBuf=[];
+      retryAfterMs = parseRetryAfter(res.headers.get('retry-after'));
+      if (!res.ok) {
+        const t = await res.text();
+        throw new RequestError(`HTTP ${res.status}: ${t}`, { status: res.status, retryAfterMs });
+      }
+      if (!res.body || typeof res.body.getReader !== 'function') {
+        throw new RequestError('响应不支持流式读取', { status: res.status, retryAfterMs });
+      }
+
+      reader = res.body.getReader();
+      const td = new TextDecoder('utf-8');
+      let buf = '';
+      let eventBuf = [];
+      let sawDone = false;
+
       const flushEvent = () => {
         if (!eventBuf.length) return;
-        const joined = eventBuf.join('\n'); eventBuf = [];
-        try{
+        const joined = eventBuf.join('\n');
+        eventBuf = [];
+        try {
           const j = JSON.parse(joined);
           const choice = j?.choices?.[0];
           let delta = choice?.delta?.content ?? choice?.text ?? '';
-          // 过滤思考内容，只保留非思考内容作为译文
           if (delta) {
-            delta = delta.replace(/<thinking>[\s\S]*?<\/thinking>/g, '')  // 标准XML标签格式
-                         .replace(/<think>[\s\S]*?<\/think>/g, '')      // 简化XML标签格式
-                         .replace(/^Thought:\s*[^\n]*\n\n/gm, '')  // 行首的Thought前缀格式（必须有双换行）
-                         .replace(/^Thinking Process:\s*[^\n]*\n\n/gm, '')  // 行首的思考过程前缀（必须有双换行）
-                         .replace(/^Internal Monologue:\s*[^\n]*\n\n/gm, '')  // 行首的内心独白前缀（必须有双换行）
-                         .replace(/\[思考\][\s\S]*?\[\/思考\]/g, '');     // 中文标签格式
+            delta = delta.replace(/<thinking>[\s\S]*?<\/thinking>/g, '')
+                         .replace(/<think>[\s\S]*?<\/think>/g, '')
+                         .replace(/^Thought:\s*[^\n]*\n\n/gm, '')
+                         .replace(/^Thinking Process:\s*[^\n]*\n\n/gm, '')
+                         .replace(/^Internal Monologue:\s*[^\n]*\n\n/gm, '')
+                         .replace(/\[思考\][\s\S]*?\[\/思考\]/g, '');
           }
-          if (typeof choice?.finish_reason === 'string') finishReason = choice.finish_reason;
-          if(delta){ onDelta(delta); lastTick = performance.now(); bytes += delta.length; events++; }
-        }catch{}
+          if (typeof choice?.finish_reason === 'string') {
+            finishReason = choice.finish_reason;
+          }
+          if (delta) {
+            onDelta(delta);
+            lastTick = performance.now();
+            bytes += delta.length;
+            events++;
+          }
+        } catch (err) {
+          d('sse:parse-error', { label, error: err?.message, payload: joined });
+        }
       };
 
-      while(true){
-        const {value, done} = await reader.read();
-        if(done) break;
-        const chunk = td.decode(value, {stream:true});
-        buf += chunk; lastTick = performance.now(); bytes += chunk.length;
-        const lines = buf.split(/\r?\n/); buf = lines.pop() || '';
-        for(const line of lines){
-          if(line.startsWith('data:')){
-            const data=line.slice(5).trim(); if(data==='[DONE]'){ flushEvent(); break; }
-            eventBuf.push(data);
-          } else if(line.trim()===''){ flushEvent(); }
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (!value || !value.length) continue;
+        const chunk = td.decode(value, { stream: true });
+        if (!chunk) continue;
+        buf += chunk;
+        lastTick = performance.now();
+        bytes += chunk.length;
+        const lines = buf.split(/\r?\n/);
+        buf = lines.pop() ?? '';
+        for (const line of lines) {
+          if (line.startsWith('data:')) {
+            const data = line.slice(5).trim();
+            if (data === '[DONE]') {
+              flushEvent();
+              sawDone = true;
+              lastTick = performance.now();
+              break;
+            }
+            if (data) eventBuf.push(data);
+          } else if (!line.trim()) {
+            flushEvent();
+          }
         }
+        if (sawDone) break;
       }
+
       if (eventBuf.length) flushEvent();
-      d('sse:complete', {label, ms: Math.round(performance.now()-startedAt), bytes, events, finishReason});
-      onFinishReason && onFinishReason(finishReason);
-    } finally { if (idleTimer) clearInterval(idleTimer); if (hardTimer) clearTimeout(hardTimer); }
+      if (sawDone && reader) {
+        try { await reader.cancel(); } catch {}
+      }
+      d('sse:complete', { label, ms: Math.round(performance.now() - startedAt), bytes, events, finishReason, sawDone });
+      if (typeof onFinishReason === 'function') onFinishReason(finishReason);
+    } catch (err) {
+      if (err instanceof RequestError) {
+        if (retryAfterMs != null && typeof err.retryAfterMs !== 'number') err.retryAfterMs = retryAfterMs;
+        throw err;
+      }
+      if (err && err.name === 'AbortError') {
+        const reason = ac.signal?.reason;
+        const reasonMsg = reason instanceof Error ? reason.message : (typeof reason === 'string' ? reason : err.message || '请求已中断');
+        throw new RequestError(reasonMsg || '请求已中断', {
+          cause: err,
+          isTimeout: /timeout/i.test(reasonMsg),
+          retryAfterMs
+        });
+      }
+      throw new RequestError(err?.message || '网络请求失败', {
+        cause: err,
+        isNetworkError: err?.name === 'TypeError',
+        retryAfterMs
+      });
+    } finally {
+      if (idleTimer) clearInterval(idleTimer);
+      if (hardTimer) clearTimeout(hardTimer);
+      if (reader) {
+        try { reader.releaseLock && reader.releaseLock(); } catch {}
+      }
+      if (res && res.body && typeof res.body.cancel === 'function') {
+        try { res.body.cancel(); } catch {}
+      }
+    }
   }
 
   async function getModels(){
@@ -2473,6 +2640,14 @@ const shouldUseCloud = hasEvansToken || isExactEvansUA;
           },
           stream: s.stream.enabled,
           label,
+          onAttempt: (attempt) => {
+            if (attempt === 1) return;
+            if (Streamer && typeof Streamer.reset === 'function') Streamer.reset(idx);
+            TransStore.set(String(idx), '');
+            if (TransStore._done) delete TransStore._done[idx];
+            if (RenderState && RenderState.lastApplied) RenderState.lastApplied[idx] = '';
+            Controller.applyDirect(idx, '<span class="ao3x-muted">（重试中…）</span>');
+          },
           onDelta: (delta) => {
             Streamer.push(idx, delta, (k, clean) => {
               TransStore.set(String(k), clean);
@@ -2639,6 +2814,14 @@ const shouldUseCloud = hasEvansToken || isExactEvansUA;
           },
           stream: s.stream.enabled,
           label,
+          onAttempt: (attempt) => {
+            if (attempt === 1) return;
+            if (Streamer && typeof Streamer.reset === 'function') Streamer.reset(idx);
+            TransStore.set(String(idx), '');
+            if (TransStore._done) delete TransStore._done[idx];
+            if (RenderState && RenderState.lastApplied) RenderState.lastApplied[idx] = '';
+            Controller.applyDirect(idx, '<span class="ao3x-muted">（重试中…）</span>');
+          },
           onDelta: (delta) => { Streamer.push(idx, delta, (k, clean)=>{ TransStore.set(String(k), clean); Controller.applyDirect(k, clean); }); },
           onFinishReason: (fr)=>{
             d('retry:finish_reason', {idx, fr});
@@ -2838,6 +3021,14 @@ const shouldUseCloud = hasEvansToken || isExactEvansUA;
           stream: !!settings.get().stream.enabled
         },
         label:`single#${i}`,
+        onAttempt: (attempt) => {
+          if (attempt === 1) return;
+          if (Streamer && typeof Streamer.reset === 'function') Streamer.reset(i);
+          TransStore.set(String(i), '');
+          if (TransStore._done) delete TransStore._done[i];
+          if (RenderState && RenderState.lastApplied) RenderState.lastApplied[i] = '';
+          Controller.applyDirect(i, '<span class="ao3x-muted">（重试中…）</span>');
+        },
         onDelta: (delta)=>{ Streamer.push(i, delta, (k, clean)=>{ View.setBlockTranslation(k, clean); }); },
         onFinishReason: (fr)=>{
           d('finish_reason', {i, fr});
@@ -2908,6 +3099,14 @@ const shouldUseCloud = hasEvansToken || isExactEvansUA;
             max_tokens: maxTokensLocal,
             stream: !!settings.get().stream.enabled
           }, stream, label,
+          onAttempt: (attempt) => {
+            if (attempt === 1) return;
+            if (Streamer && typeof Streamer.reset === 'function') Streamer.reset(i);
+            TransStore.set(String(i), '');
+            if (TransStore._done) delete TransStore._done[i];
+            if (RenderState && RenderState.lastApplied) RenderState.lastApplied[i] = '';
+            Controller.applyDirect(i, '<span class="ao3x-muted">（重试中…）</span>');
+          },
           onDelta: (delta)=>{ Streamer.push(i, delta, (k, clean)=>{ View.setBlockTranslation(k, clean); }); },
           onFinishReason: async (fr)=>{
             d('finish_reason', {i, fr});
@@ -2932,6 +3131,14 @@ const shouldUseCloud = hasEvansToken || isExactEvansUA;
                     temperature: settings.get().gen.temperature,
                     max_tokens: newMax,
                     stream: !!settings.get().stream.enabled
+                  },
+                  onAttempt: (attempt2) => {
+                    if (attempt2 === 1) return;
+                    if (Streamer && typeof Streamer.reset === 'function') Streamer.reset(i);
+                    TransStore.set(String(i), '');
+                    if (TransStore._done) delete TransStore._done[i];
+                    if (RenderState && RenderState.lastApplied) RenderState.lastApplied[i] = '';
+                    Controller.applyDirect(i, '<span class="ao3x-muted">（重试中…）</span>');
                   },
                   onDelta: (delta)=>{ Streamer.push(i, delta, (k, clean)=>{ View.setBlockTranslation(k, clean); }); },
                   onFinishReason: (fr2)=>{
@@ -3359,6 +3566,13 @@ const shouldUseCloud = hasEvansToken || isExactEvansUA;
           stream: !!settings.get().stream.enabled
         },
         label: `summary-single#${i}`,
+        onAttempt: (attempt) => {
+          if (attempt === 1) return;
+          if (SummaryStreamer && typeof SummaryStreamer.reset === 'function') SummaryStreamer.reset(i);
+          SummaryStore.set(String(i), '');
+          if (SummaryStore._done) delete SummaryStore._done[i];
+          this.applyIncremental(i, '<span class="ao3x-muted">（重试中…）</span>');
+        },
         onDelta: (delta) => {
           // 使用专用的 SummaryStreamer，与翻译分离缓冲区
           SummaryStreamer.push(i, delta, (k, clean) => {
@@ -3448,6 +3662,13 @@ const shouldUseCloud = hasEvansToken || isExactEvansUA;
           },
           stream,
           label,
+          onAttempt: (attempt) => {
+            if (attempt === 1) return;
+            if (SummaryStreamer && typeof SummaryStreamer.reset === 'function') SummaryStreamer.reset(i);
+            SummaryStore.set(String(i), '');
+            if (SummaryStore._done) delete SummaryStore._done[i];
+            this.applyIncremental(i, '<span class="ao3x-muted">（重试中…）</span>');
+          },
           onDelta: (delta) => {
             // 使用专用的 SummaryStreamer，与翻译分离缓冲区
             SummaryStreamer.push(i, delta, (k, clean) => {
@@ -3539,6 +3760,15 @@ const shouldUseCloud = hasEvansToken || isExactEvansUA;
       if (!raw) return '';
       const html = /[<][a-zA-Z]/.test(raw) ? raw : raw.replace(/\n/g, '<br/>');
       return sanitizeHTML(html);
+    },
+    reset(i){
+      if (typeof i === 'number') {
+        this._buf[i] = '';
+        this._dirty[i] = false;
+      } else {
+        this._buf = Object.create(null);
+        this._dirty = Object.create(null);
+      }
     },
     schedule(apply, force = false) {
       const { minFrameMs } = (typeof settings !== 'undefined' ? settings.get().stream : { minFrameMs: 40 });


### PR DESCRIPTION
## Summary
- introduce structured `RequestError` handling with retry classification, retry-after support, and configurable backoff delays
- harden SSE streaming to close cleanly on `[DONE]`, normalize network failures, and surface parse issues for debugging
- reset per-chunk buffers and DOM placeholders on retry attempts to avoid duplicated or garbled output in translation and summary flows

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68ca5ef95818832089a254c805268a70